### PR TITLE
chore: apply rust 2018 idioms lint

### DIFF
--- a/redis-test/src/lib.rs
+++ b/redis-test/src/lib.rs
@@ -23,6 +23,8 @@
 //! assert_eq!(result, true);
 //! ```
 
+#![deny(rust_2018_idioms)]
+
 use std::collections::VecDeque;
 use std::iter::FromIterator;
 use std::sync::{Arc, Mutex};

--- a/redis/src/aio/async_std.rs
+++ b/redis/src/aio/async_std.rs
@@ -66,7 +66,7 @@ where
 {
     fn poll_write(
         self: Pin<&mut Self>,
-        cx: &mut core::task::Context,
+        cx: &mut core::task::Context<'_>,
         buf: &[u8],
     ) -> std::task::Poll<Result<usize, tokio::io::Error>> {
         async_std::io::Write::poll_write(self.project().inner, cx, buf)
@@ -74,14 +74,14 @@ where
 
     fn poll_flush(
         self: Pin<&mut Self>,
-        cx: &mut core::task::Context,
+        cx: &mut core::task::Context<'_>,
     ) -> std::task::Poll<Result<(), tokio::io::Error>> {
         async_std::io::Write::poll_flush(self.project().inner, cx)
     }
 
     fn poll_shutdown(
         self: Pin<&mut Self>,
-        cx: &mut core::task::Context,
+        cx: &mut core::task::Context<'_>,
     ) -> std::task::Poll<Result<(), tokio::io::Error>> {
         async_std::io::Write::poll_close(self.project().inner, cx)
     }
@@ -93,7 +93,7 @@ where
 {
     fn poll_read(
         self: Pin<&mut Self>,
-        cx: &mut core::task::Context,
+        cx: &mut core::task::Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> std::task::Poll<Result<(), tokio::io::Error>> {
         let n = ready!(async_std::io::Read::poll_read(
@@ -124,7 +124,7 @@ pub enum AsyncStd {
 impl AsyncWrite for AsyncStd {
     fn poll_write(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         match &mut *self {
@@ -139,7 +139,7 @@ impl AsyncWrite for AsyncStd {
         }
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             AsyncStd::Tcp(r) => Pin::new(r).poll_flush(cx),
             #[cfg(any(
@@ -152,7 +152,7 @@ impl AsyncWrite for AsyncStd {
         }
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             AsyncStd::Tcp(r) => Pin::new(r).poll_shutdown(cx),
             #[cfg(any(
@@ -169,7 +169,7 @@ impl AsyncWrite for AsyncStd {
 impl AsyncRead for AsyncStd {
     fn poll_read(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         match &mut *self {

--- a/redis/src/aio/multiplexed_connection.rs
+++ b/redis/src/aio/multiplexed_connection.rs
@@ -103,7 +103,7 @@ where
     }
 
     // Read messages from the stream and send them back to the caller
-    fn poll_read(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Result<(), ()>> {
+    fn poll_read(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<(), ()>> {
         loop {
             // No need to try reading a message if there is no message in flight
             if self.in_flight.is_empty() {
@@ -168,7 +168,7 @@ where
     // Retrieve incoming messages and write them to the sink
     fn poll_ready(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         match ready!(self.as_mut().project().sink_stream.poll_ready(cx)) {
             Ok(()) => Ok(()).into(),
@@ -217,7 +217,7 @@ where
 
     fn poll_flush(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         ready!(self
             .as_mut()
@@ -232,7 +232,7 @@ where
 
     fn poll_close(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         // No new requests will come in after the first call to `close` but we need to complete any
         // in progress requests before closing

--- a/redis/src/aio/tokio.rs
+++ b/redis/src/aio/tokio.rs
@@ -63,7 +63,7 @@ pub(crate) enum Tokio {
 impl AsyncWrite for Tokio {
     fn poll_write(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         match &mut *self {
@@ -75,7 +75,7 @@ impl AsyncWrite for Tokio {
         }
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_flush(cx),
             #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
@@ -85,7 +85,7 @@ impl AsyncWrite for Tokio {
         }
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<io::Result<()>> {
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
         match &mut *self {
             Tokio::Tcp(r) => Pin::new(r).poll_shutdown(cx),
             #[cfg(any(feature = "tokio-native-tls-comp", feature = "tokio-rustls-comp"))]
@@ -99,7 +99,7 @@ impl AsyncWrite for Tokio {
 impl AsyncRead for Tokio {
     fn poll_read(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         match &mut *self {

--- a/redis/src/cluster_async/mod.rs
+++ b/redis/src/cluster_async/mod.rs
@@ -249,7 +249,7 @@ where
 {
     type Output = Next<I, C>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         let mut this = self.as_mut().project();
         if this.request.is_none() {
             return Poll::Ready(Next::Done);
@@ -937,7 +937,7 @@ where
 
     fn poll_ready(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         match mem::replace(&mut self.state, ConnectionState::PollComplete) {
             ConnectionState::PollComplete => Poll::Ready(Ok(())),
@@ -980,7 +980,7 @@ where
 
     fn poll_flush(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         trace!("poll_complete: {:?}", self.state);
         loop {
@@ -1023,7 +1023,7 @@ where
 
     fn poll_close(
         mut self: Pin<&mut Self>,
-        cx: &mut task::Context,
+        cx: &mut task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
         // Try to drive any in flight requests to completion
         match self.poll_complete(cx) {

--- a/redis/src/cluster_routing.rs
+++ b/redis/src/cluster_routing.rs
@@ -449,7 +449,7 @@ impl SlotMap {
         self.0.clear();
     }
 
-    pub fn values(&self) -> std::collections::btree_map::Values<u16, SlotAddrs> {
+    pub fn values(&self) -> std::collections::btree_map::Values<'_, u16, SlotAddrs> {
         self.0.values()
     }
 

--- a/redis/src/cmd.rs
+++ b/redis/src/cmd.rs
@@ -81,7 +81,7 @@ struct AsyncIterInner<'a, T: FromRedisValue + 'a> {
 
 /// Represents the state of AsyncIter
 #[cfg(feature = "aio")]
-enum IterOrFuture<'a, T: FromRedisValue + 'a> {
+enum IterOrFuture<'a, T: FromRedisValue> {
     Iter(AsyncIterInner<'a, T>),
     Future(BoxFuture<'a, (AsyncIterInner<'a, T>, Option<T>)>),
     Empty,
@@ -89,7 +89,7 @@ enum IterOrFuture<'a, T: FromRedisValue + 'a> {
 
 /// Represents a redis iterator that can be used with async connections.
 #[cfg(feature = "aio")]
-pub struct AsyncIter<'a, T: FromRedisValue + 'a> {
+pub struct AsyncIter<'a, T: FromRedisValue> {
     inner: IterOrFuture<'a, T>,
 }
 

--- a/redis/src/commands/macros.rs
+++ b/redis/src/commands/macros.rs
@@ -172,7 +172,7 @@ macro_rules! implement_commands {
 
             /// Incrementally iterate the keys space.
             #[inline]
-            fn scan<RV: FromRedisValue>(&mut self) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+            fn scan<RV: FromRedisValue>(&mut self) -> crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SCAN");
                 c.cursor_arg(0);
                 Box::pin(async move { c.iter_async(self).await })
@@ -180,7 +180,7 @@ macro_rules! implement_commands {
 
             /// Incrementally iterate set elements for elements matching a pattern.
             #[inline]
-            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+            fn scan_match<P: ToRedisArgs, RV: FromRedisValue>(&mut self, pattern: P) -> crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SCAN");
                 c.cursor_arg(0).arg("MATCH").arg(pattern);
                 Box::pin(async move { c.iter_async(self).await })
@@ -188,7 +188,7 @@ macro_rules! implement_commands {
 
             /// Incrementally iterate hash fields and associated values.
             #[inline]
-            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+            fn hscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("HSCAN");
                 c.arg(key).cursor_arg(0);
                 Box::pin(async move {c.iter_async(self).await })
@@ -198,7 +198,7 @@ macro_rules! implement_commands {
             /// field names matching a pattern.
             #[inline]
             fn hscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("HSCAN");
                 c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
                 Box::pin(async move {c.iter_async(self).await })
@@ -206,7 +206,7 @@ macro_rules! implement_commands {
 
             /// Incrementally iterate set elements.
             #[inline]
-            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+            fn sscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SSCAN");
                 c.arg(key).cursor_arg(0);
                 Box::pin(async move {c.iter_async(self).await })
@@ -215,7 +215,7 @@ macro_rules! implement_commands {
             /// Incrementally iterate set elements for elements matching a pattern.
             #[inline]
             fn sscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("SSCAN");
                 c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
                 Box::pin(async move {c.iter_async(self).await })
@@ -223,7 +223,7 @@ macro_rules! implement_commands {
 
             /// Incrementally iterate sorted set elements.
             #[inline]
-            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+            fn zscan<K: ToRedisArgs, RV: FromRedisValue>(&mut self, key: K) -> crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("ZSCAN");
                 c.arg(key).cursor_arg(0);
                 Box::pin(async move {c.iter_async(self).await })
@@ -232,7 +232,7 @@ macro_rules! implement_commands {
             /// Incrementally iterate sorted set elements for elements matching a pattern.
             #[inline]
             fn zscan_match<K: ToRedisArgs, P: ToRedisArgs, RV: FromRedisValue>
-                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<crate::cmd::AsyncIter<'_, RV>> {
+                    (&mut self, key: K, pattern: P) -> crate::types::RedisFuture<'_, crate::cmd::AsyncIter<'_, RV>> {
                 let mut c = cmd("ZSCAN");
                 c.arg(key).cursor_arg(0).arg("MATCH").arg(pattern);
                 Box::pin(async move {c.iter_async(self).await })

--- a/redis/src/connection.rs
+++ b/redis/src/connection.rs
@@ -144,7 +144,7 @@ impl ConnectionAddr {
 }
 
 impl fmt::Display for ConnectionAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Cluster::get_connection_info depends on the return value from this function
         match *self {
             ConnectionAddr::Tcp(ref host, port) => write!(f, "{host}:{port}"),

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -356,7 +356,7 @@ assert_eq!(result, Ok(("foo".to_string(), b"bar".to_vec())));
 //! [`futures`]:https://crates.io/crates/futures
 //! [`tokio`]:https://tokio.rs
 
-#![deny(non_camel_case_types)]
+#![deny(rust_2018_idioms, non_camel_case_types)]
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, warn(rustdoc::broken_intra_doc_links))]
 #![cfg_attr(docsrs, feature(doc_cfg))]


### PR DESCRIPTION
will submit to redis-rs when https://github.com/redis-rs/redis-rs/pull/934 is merged

---

`rust_2018_idioms` is a lint group containing things that are likely to become errors in a future edition, and also improves comprehensibility. In this case, mostly due to elided lifetimes parameters.